### PR TITLE
'\c' is for case intensive AND '\C' is for case tensive

### DIFF
--- a/ch12_search_and_substitute.md
+++ b/ch12_search_and_substitute.md
@@ -31,7 +31,7 @@ You can control case insensitivity with the case of your search phrase:
 - `/HELLO` matches only "HELLO".
 - `/Hello` matches only "Hello"
 
-There is one downside. What if you need to search for only a lowercase string? When you do `/hello`, Vim will always match its uppercase variants. What if you don't want to match them? You can use `\c` pattern in front of your search term to tell Vim that the subsequent search term will be case sensitive. If you do `/\chello`, it will strictly match "hello", not "HELLO" or "Hello".
+There is one downside. What if you need to search for only a lowercase string? When you do `/hello`, Vim will always match its uppercase variants. What if you don't want to match them? You can use `\C` pattern in front of your search term to tell Vim that the subsequent search term will be case sensitive. If you do `/\Chello`, it will strictly match "hello", not "HELLO" or "Hello".
 
 # First and Last Character in a Line
 


### PR DESCRIPTION
Vim documents says:

Examples:
      pattern   'ignorecase'  'smartcase'       matches ~
        foo       off           -               foo
        foo       on            -               foo Foo FOO
        Foo       on            off             foo Foo FOO
        Foo       on            on                  Foo
        \cfoo     -             -               foo Foo FOO
        foo\C     -             -               foo
