### PR TITLE
Fix "Allows" Typo

### DIFF
--- a/ch01_starting_vim.md
+++ b/ch01_starting_vim.md
@@ -161,6 +161,6 @@ If you need to suspend Vim while in the middle of editing, you can press `Ctrl-z
 
 ## Starting Vim the Smart Way
 
-The `vim` command can take many different options, just like any other terminal command. Two options allows to pass a Vim command as a parameter: `+{cmd}` and `-c cmd`. As you learn more commands throughout this guide, see if you can apply it when starting Vim. Also being a terminal command, you can combine `vim` with many other terminal commands. For example, you can redirect the output of the `ls` command to be edited in Vim with `ls -l | vim -`.
+The `vim` command can take many different options, just like any other terminal command. Two options allow you to pass a Vim command as a parameter: `+{cmd}` and `-c cmd`. As you learn more commands throughout this guide, see if you can apply it when starting Vim. Also being a terminal command, you can combine `vim` with many other terminal commands. For example, you can redirect the output of the `ls` command to be edited in Vim with `ls -l | vim -`.
 
 To learn more about `vim` command in the terminal, check out `man vim`. To learn more about the Vim editor, continue reading this guide along with the `:help` command.


### PR DESCRIPTION
Typo fixed in "Starting Vim the Smart Way" section.