### PR TITLE
Correction in "Current Line Navigation" topic

### DIFF
--- a/ch05_moving_in_file.md
+++ b/ch05_moving_in_file.md
@@ -101,7 +101,7 @@ n|    Go the column n in the current line
 
 You can do current line search with `f` and `t`. The difference between `f` and `t` is that `f` takes you to the first letter of the match and `t` takes you till (right before) the first letter of the match. So if you want to search for "h" and land on "h", use `fh`. If you want to search for first "h" and land right before the match, use `th`. If you want to go to the *next* occurrence of the last current line search, use `;`. To go to the previous occurrence of the last current line match, use `,`.
 
-`F` and `T` are the backward counterparts of `f` and `t`. To search backwards for "h", run `Fh`. To keep searching for "h" in the same direction, use `;`. Note that `;` after a `Fh` searches backward and `,` after `fh` searches forward. 
+`F` and `T` are the backward counterparts of `f` and `t`. To search backwards for "h", run `Fh`. To keep searching for "h" in the same direction, use `;`. Note that `;` after a `Fh` searches backward and `,` after `Fh` searches forward. 
 
 ```
 f    Search forward for a match in the same line


### PR DESCRIPTION
`,` repeats the last search in the same line using the opposite direction. So `Fh` should search in the forward direction when used with `,`.