### PR TITLE
Improve Visual Block command doc

### DIFF
--- a/ch07_the_dot_command.md
+++ b/ch07_the_dot_command.md
@@ -94,6 +94,8 @@ Let's remove all the z's. Starting from the first character on the first line, v
 
 When you deleted a column of three z's (`Ctrl-vjjd`), it was counted as a change. Visual mode operation can be used to target multiple lines as part of a change.
 
+If (`Crtl-V`) doesn't switch the window to VISUAL BLOCK mode, you can try (`Ctrl-Q`), read more at: [Ctrl-V don't work in WLS](https://vi.stackexchange.com/questions/12227/vim-v-visual-block-mode-not-working)
+
 ## Including a Motion in a Change
 
 Let's revisit the first example in this chapter. Recall that the command `/letcwconst<Esc>` followed by `n . n .`  replaced all "let" with "const" in the following expressions:

--- a/ch07_the_dot_command.md
+++ b/ch07_the_dot_command.md
@@ -94,7 +94,7 @@ Let's remove all the z's. Starting from the first character on the first line, v
 
 When you deleted a column of three z's (`Ctrl-vjjd`), it was counted as a change. Visual mode operation can be used to target multiple lines as part of a change.
 
-If (`Crtl-V`) doesn't switch the window to VISUAL BLOCK mode, you can try (`Ctrl-Q`), read more at: [Ctrl-V don't work in WLS](https://vi.stackexchange.com/questions/12227/vim-v-visual-block-mode-not-working)
+If `Crtl-V` doesn't switch the window to VISUAL BLOCK mode, you can try (`Ctrl-Q`), read more at: [Ctrl-V don't work in WLS](https://vi.stackexchange.com/questions/12227/vim-v-visual-block-mode-not-working).
 
 ## Including a Motion in a Change
 


### PR DESCRIPTION
- Ctrl-V not work in WSL command environment, I update the doc for user from window to have better sense from what happens
- Add reference for the update