### PR TITLE
Fix a typo in ch25_vimscript_basic_data_types.md

### DIFF
--- a/ch25_vimscript_basic_data_types.md
+++ b/ch25_vimscript_basic_data_types.md
@@ -651,7 +651,7 @@ To check the length of a dictionary, use `len()`.
 ```
 :let mealPlans = #{breakfast: "waffles", lunch: "pancakes", dinner: "donuts"}
 
-:echo len(meaPlans)
+:echo len(mealPlans)
 " returns 3
 ```
 


### PR DESCRIPTION
Fix a typo of `meaPlans` which should be `mealPlans`.