### PR TITLE
Correct typos with overuse of backslashes.

### DIFF
--- a/ch26_vimscript_conditionals_and_loops.md
+++ b/ch26_vimscript_conditionals_and_loops.md
@@ -476,14 +476,14 @@ The difference between `catch` and `finally` is that `finally` is always run, er
 You can catch specific error with `:catch`. According to `:h :catch`:
 
 ```
-catch /^Vim:Interrupt$/.             " catch interrupts (CTRL-C)
-catch /^Vim\\%((\\a\\+)\\)\\=:E/.    " catch all Vim errors
-catch /^Vim\\%((\\a\\+)\\)\\=:/.     " catch errors and interrupts
-catch /^Vim(write):/.                " catch all errors in :write
-catch /^Vim\\%((\\a\\+)\\)\\=:E123:/ " catch error E123
-catch /my-exception/.                " catch user exception
-catch /.*/                           " catch everything
-catch.                               " same as /.*/
+catch /^Vim:Interrupt$/.		" catch interrupts (CTRL-C)
+catch /^Vim\\%((\a\+)\)\=:E/.	" catch all Vim errors
+catch /^Vim\%((\a\+)\)\=:/.     " catch errors and interrupts
+catch /^Vim(write):/.			" catch all errors in :write
+catch /^Vim\%((\a\+)\)\=:E123:/	" catch error E123
+catch /my-exception/.			" catch user exception
+catch /.*/						" catch everything
+catch.							" same as /.*/
 ```
 
 Inside a `try` block, an interrupt is considered a catchable error.


### PR DESCRIPTION
After testing the code examples in a vimscript I was writing, I was able to determine that multiple backslashes were not necessary and actually led to vim misinterpreting the `try`/`catch` blocks I was implementing based on this information.

For example, when I used this

```vim
catch /^Vim\\%((\\a\\+)\\)\\=:E185:/ 
```

vim would never catch the error when I would intentionally setup the script to trigger the error. When I reviewed `:h :catch` I noticed that it does not have those same backslashes present.

```text
:cat[ch] /{pattern}/	The following commands until the next |:catch|,
			|:finally|, or |:endtry| that belongs to the same
			|:try| as the ":catch" are executed when an exception
			matching {pattern} is being thrown and has not yet
			been caught by a previous ":catch".  Otherwise, these
			commands are skipped.
			When {pattern} is omitted all errors are caught.
			Examples: >
		:catch /^Vim:Interrupt$/	 " catch interrupts (CTRL-C)
		:catch /^Vim\%((\a\+)\)\=:E/	 " catch all Vim errors
		:catch /^Vim\%((\a\+)\)\=:/	 " catch errors and interrupts
		:catch /^Vim(write):/		 " catch all errors in :write
		:catch /^Vim\%((\a\+)\)\=:E123:/ " catch error E123
		:catch /my-exception/		 " catch user exception
		:catch /.*/			 " catch everything
		:catch				 " same as /.*/

			Another character can be used instead of / around the
			{pattern}, so long as it does not have a special
			meaning (e.g., '|' or '"') and doesn't occur inside
			{pattern}.
			Information about the exception is available in
			|v:exception|.  Also see |throw-variables|.
			NOTE: It is not reliable to ":catch" the TEXT of
			an error message because it may vary in different
			locales.
```

I removed the additional backslashes matching what's in `:h :catch`.

```vim
catch /^Vim\%((\a\+)\)\=:E185:/ 
```
When I made this change vim correctly caught the error and execution of the script worked as intended.

This mistake appears to also be present on [this website](https://learnvim.irian.to/vimscript/vimscript_conditionals_and_loops#try-finally-and-catch).

![image](https://github.com/iggredible/Learn-Vim/assets/1657434/7b3a3264-7180-47c9-8b89-5bbcdeb54eef)

I'm unsure if the owner of that site is the same as the author of this repository, but if they are, they should correct it there as well. I could see this kind of mistake tripping up new users learning about vim and it would very unfortunate for a website that does such an excellent job presenting this information to create confusion for users reading it.